### PR TITLE
Fix http/500 error

### DIFF
--- a/luxmedSnip.py
+++ b/luxmedSnip.py
@@ -133,6 +133,7 @@ class LuxMedSniper:
             "languageId": 10,
             "searchDateFrom": datetime.date.today().strftime("%Y-%m-%d"),
             "searchDateTo": date_to.strftime("%Y-%m-%d"),
+            "delocalized": False
         }
         if clinicIds != '-1':
             params['facilitiesIds'] = clinicIds.split(',')


### PR DESCRIPTION
At this point, the patient portal responds with the error http/500 (see #28): 

> ERROR Expecting value: line 2 column 1 (char 2). 

This small correction fixes this error.  I compared the header sent to the patient portal with the one from the script and I added this missing parameter, after which I already got a response. This is certainly a reasonably quick workaround for the current problem. Probably a more thorough analysis would be useful here :P